### PR TITLE
Fix input type check in multiple options test

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -125,7 +125,7 @@ func TestOptions(t *testing.T) {
 				t.Errorf("expected startup options have %v, got %v", opt, p.startupOptions)
 			}
 			if p.inputType != ttyInput {
-				t.Errorf("expected input to be %v, got %v", opt, p.startupOptions)
+				t.Errorf("expected input type to be %v, got %v", ttyInput, p.inputType)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
- in `options_test.go`, update the error message in the `multiple` subtest
- print the expected and actual input types directly

## Testing
- `go test ./...` *(fails: no route to host)*