### PR TITLE
Fix double-click mouse event on Windows

### DIFF
--- a/key_windows.go
+++ b/key_windows.go
@@ -139,11 +139,26 @@ func mouseEvent(p coninput.ButtonState, e coninput.MouseEventRecord) MouseMsg {
 		Shift: e.ControlKeyState.Contains(coninput.SHIFT_PRESSED),
 	}
 	switch e.EventFlags {
-	case coninput.CLICK, coninput.DOUBLE_CLICK:
+	case coninput.CLICK:
 		ev.Button, ev.Action = mouseEventButton(p, e.ButtonState)
 		if ev.Action == MouseActionRelease {
 			ev.Type = MouseRelease
 		}
+		switch ev.Button {
+		case MouseButtonLeft:
+			ev.Type = MouseLeft
+		case MouseButtonMiddle:
+			ev.Type = MouseMiddle
+		case MouseButtonRight:
+			ev.Type = MouseRight
+		case MouseButtonBackward:
+			ev.Type = MouseBackward
+		case MouseButtonForward:
+			ev.Type = MouseForward
+		}
+	case coninput.DOUBLE_CLICK:
+		ev.Button, _ = mouseEventButton(p, e.ButtonState)
+		ev.Action = MouseActionPress
 		switch ev.Button {
 		case MouseButtonLeft:
 			ev.Type = MouseLeft

--- a/mouse_windows_test.go
+++ b/mouse_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package tea
+
+import (
+	"github.com/erikgeiser/coninput"
+	"testing"
+)
+
+func TestMouseEventDoubleClick(t *testing.T) {
+	// Previous state: no buttons pressed
+	var prev coninput.ButtonState
+	// Simulate a double click event at position (10,5) with left button
+	e := coninput.MouseEventRecord{
+		EventFlags:   coninput.DOUBLE_CLICK,
+		ButtonState:  coninput.FROM_LEFT_1ST_BUTTON_PRESSED,
+		MousePositon: coninput.Coord{X: 10, Y: 5},
+	}
+
+	got := mouseEvent(prev, e)
+	want := MouseMsg{
+		X:      10,
+		Y:      5,
+		Button: MouseButtonLeft,
+		Action: MouseActionPress,
+		Type:   MouseLeft,
+	}
+
+	if got != want {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- handle double-click mouse events on Windows as presses instead of releases
- add Windows-specific test verifying correct double-click handling

## Testing
- `go test ./...` *(fails: unable to download modules)*